### PR TITLE
Improve exception handling for METS files

### DIFF
--- a/storer/routines.py
+++ b/storer/routines.py
@@ -92,11 +92,11 @@ class StoreRoutine(Routine):
             else:
                 raise RoutineError("Unrecognized package type: {}".format(package.type), self.uuid)
 
-            package.internal_sender_identifier, self.mimetypes, origin, archivesspace_uri = self.parse_mets()
+            mets_data = self.parse_mets()
 
             try:
                 container = self.fedora_client.create_container(self.uuid)
-                getattr(self, 'store_{}'.format(package.type))(package.data, container)
+                getattr(self, 'store_{}'.format(package.type))(package.data, container, mets_data['mimetypes'])
             except Exception as e:
                 raise RoutineError("Error storing data: {}".format(e), self.uuid)
 
@@ -105,16 +105,17 @@ class StoreRoutine(Routine):
                     helpers.send_post_request(
                         self.url,
                         {
-                            'identifier': package.internal_sender_identifier,
+                            'identifier': mets_data['internal_sender_identifier'],
                             'uri': container.uri_as_string(),
                             'package_type': package.type,
-                            'origin': origin,
-                            'archivesspace_uri': archivesspace_uri,
+                            'origin': mets_data['origin'],
+                            'archivesspace_uri': mets_data['archivesspace_uri'],
                         }
                     )
                 except Exception as e:
-                    raise RoutineError("Error sending post callback: {}".format(e), self.uuid)
+                    raise RoutineError("Error sending POST request to {}: {}".format(self.url, e), self.uuid)
 
+            package.internal_sender_identifier = mets_data['internal_sender_identifier']
             package.process_status = Package.STORED
             package.save()
 
@@ -136,45 +137,57 @@ class StoreRoutine(Routine):
         and mimetypes
         """
         try:
-            mimetypes = {}
+            mets_data = {}
             mets = helpers.extract_file(join(self.tmp_dir, "{}{}".format(self.uuid, self.extension)), self.mets_path, join(self.tmp_dir, "METS.{}.xml".format(self.uuid)))
             tree = ET.parse(mets)
             root = tree.getroot()
             ns = {'mets': 'http://www.loc.gov/METS/', 'premis': 'info:lc/xmlns/premis-v2', 'fits': 'http://hul.harvard.edu/ois/xml/ns/fits/fits_output'}
             bagit_root = "mets:amdSec/mets:sourceMD/mets:mdWrap[@OTHERMDTYPE='BagIt']/mets:xmlData/transfer_metadata/"
-            internal_sender_identifier = root.findtext("{}/Internal-Sender-Identifier".format(bagit_root), namespaces=ns)
-            origin = root.findtext("{}/Origin".format(bagit_root), namespaces=ns)
-            archivesspace_uri = root.findtext("{}/ArchivesSpace-URI".format(bagit_root), namespaces=ns)
+            mets_data['internal_sender_identifier'] = self.findtext_with_exception(root, "{}/Internal-Sender-Identifier".format(bagit_root), ns)
+            mets_data['archivesspace_uri'] = root.findtext("{}/ArchivesSpace-URI".format(bagit_root), namespaces=ns)
+            mets_data['origin'] = root.findtext("{}/Origin".format(bagit_root), default="aurora", namespaces=ns)
             files = root.findall('mets:amdSec/mets:techMD/mets:mdWrap[@MDTYPE="PREMIS:OBJECT"]/mets:xmlData/premis:object', ns)
+            mimetypes = {}
             for f in files:
-                uuid = f.findtext('premis:objectIdentifier/premis:objectIdentifierValue', namespaces=ns)
+                uuid = self.findtext_with_exception(f, 'premis:objectIdentifier/premis:objectIdentifierValue', ns)
                 identity = f.find('premis:objectCharacteristics/premis:objectCharacteristicsExtension/', ns)
                 mtype = identity.attrib.get('mimetype', 'application/octet-stream') if identity else 'application/octet-stream'
                 mimetypes.update({uuid: mtype})
-            return internal_sender_identifier, mimetypes, origin, archivesspace_uri
+            mets_data['mimetypes'] = mimetypes
+            return mets_data
+        except FileNotFoundError:
+            raise RoutineError("No METS file found at {}".format(self.mets_path), self.uuid)
+        except ValueError as e:
+            raise RoutineError("Could not find element {} in METS file".format(e), self.uuid)
         except Exception as e:
             raise RoutineError("Error getting data from Archivematica METS file: {}".format(e), self.uuid)
+
+    def findtext_with_exception(self, element, xpath, namespaces):
+        ret = element.findtext(xpath, namespaces=namespaces)
+        if not ret:
+            raise ValueError(xpath)
+        return ret
 
     def clean_up(self, uuid):
         for d in listdir(self.tmp_dir):
             if uuid in d:
                 helpers.remove_file_or_dir(join(self.tmp_dir, d))
 
-    def store_aip(self, package, container):
+    def store_aip(self, package, container, mimetypes):
         """
         Stores an AIP as a single binary in Fedora and handles the resulting URI.
         Assumes AIPs are stored as a compressed package.
         """
         self.fedora_client.create_binary(join(self.tmp_dir, "{}{}".format(self.uuid, self.extension)), container, 'application/x-7z-compressed')
 
-    def store_dip(self, package, container):
+    def store_dip(self, package, container, mimetypes):
         """
         Stores a DIP as multiple binaries in Fedora and handles the resulting URI.
         Matches the file UUID (the first 36 characters of the filename) against
         the mimetypes dictionary to find the relevant mimetype.
         """
         for f in listdir(join(self.extracted, 'objects')):
-            mimetype = self.mimetypes[f[0:36]]
+            mimetype = mimetypes[f[0:36]]
             self.fedora_client.create_binary(join(self.tmp_dir, self.uuid, 'objects', f), container, mimetype)
 
 

--- a/storer/tests.py
+++ b/storer/tests.py
@@ -65,17 +65,17 @@ class PackageTest(TestCase):
         with storer_vcr.use_cassette('download.yml'):
             request = self.factory.post(reverse('download-packages'), {"test": True})
             response = DownloadView.as_view()(request)
-            self.assertEqual(response.status_code, 200, "Wrong HTTP code")
+            self.assertEqual(response.status_code, 200, "Return error: {}".format(response.data))
             self.assertEqual(response.data['count'], 1, "Wrong number of packages downloaded")
         with storer_vcr.use_cassette('store.yml'):
             request = self.factory.post(reverse('store-packages'), {"test": True})
             response = StoreView.as_view()(request)
-            self.assertEqual(response.status_code, 200, "Wrong HTTP code")
+            self.assertEqual(response.status_code, 200, "Return error: {}".format(response.data))
             self.assertEqual(response.data['count'], 1, "Wrong number of packages stored")
         with storer_vcr.use_cassette('cleanup.yml'):
             request = self.factory.post("{}?post_service_url=http://fornax-web:8003/cleanup/".format(reverse('request-cleanup')), {"test": True})
             response = CleanupRequestView.as_view()(request)
-            self.assertEqual(response.status_code, 200, "Wrong HTTP code")
+            self.assertEqual(response.status_code, 200, "Return error: {}".format(response.data))
 
     def schema(self):
         print('*** Getting schema view ***')


### PR DESCRIPTION
Adds some nuance to the try/except for parsing METS files. Implements a method to throw a `ValueError` exception when elements are not found, and also targets `FileNotFound` exceptions with a different error message.

@bonniegee Note [the line which gets `origin`](https://github.com/RockefellerArchiveCenter/gemini/blob/issue-97/storer/routines.py#L147), which provides a default value of "aurora". I did this because it allows us to decouple the deployment of this code from the deployment of upstream changes in Aurora and elsewhere which add the `Origin` tag to `bag-info.txt` files. If this is acceptable to you, I propose we add two issues:
- use `findtext_with_exception()` for `Origin` once Aurora `v2.0` is deployed.
- Update tests/fixtures to include bags from non-Aurora origins 

fixes #97 