### PR TITLE
Improves METS parsing

### DIFF
--- a/storer/clients.py
+++ b/storer/clients.py
@@ -33,14 +33,14 @@ class FedoraClient(object):
         except Exception as e:
             raise FedoraClientError("Error creating object: {}".format(e))
 
-    def create_binary(self, filepath, container, mimetype):
+    def create_binary(self, filepath, container):
         # Uses PCDM plugin: https://github.com/ghukill/pyfc4/blob/master/pyfc4/plugins/pcdm/models.py
         with open(filepath, 'rb') as f:
             try:
                 binary = pcdm.PCDMFile(repo=self.client, uri='{}/files/{}'.format(container.uri_as_string(), basename(filepath)))
                 if binary.check_exists():
                     binary.delete(remove_tombstone=True)
-                new_binary = pcdm.PCDMFile(repo=self.client, uri='{}/files/{}'.format(container.uri_as_string(), basename(filepath)), binary_data=f, binary_mimetype=mimetype)
+                new_binary = pcdm.PCDMFile(repo=self.client, uri='{}/files/{}'.format(container.uri_as_string(), basename(filepath)), binary_data=f, binary_mimetype=None)
                 new_binary.create(specify_uri=True, auto_refresh=False)
                 new_binary.add_triple(new_binary.rdf.prefixes.rdfs['label'], basename(filepath))
                 new_binary.add_triple(new_binary.rdf.prefixes.dc['format'], mimetype)

--- a/storer/clients.py
+++ b/storer/clients.py
@@ -33,14 +33,14 @@ class FedoraClient(object):
         except Exception as e:
             raise FedoraClientError("Error creating object: {}".format(e))
 
-    def create_binary(self, filepath, container):
+    def create_binary(self, filepath, container, mimetype):
         # Uses PCDM plugin: https://github.com/ghukill/pyfc4/blob/master/pyfc4/plugins/pcdm/models.py
         with open(filepath, 'rb') as f:
             try:
                 binary = pcdm.PCDMFile(repo=self.client, uri='{}/files/{}'.format(container.uri_as_string(), basename(filepath)))
                 if binary.check_exists():
                     binary.delete(remove_tombstone=True)
-                new_binary = pcdm.PCDMFile(repo=self.client, uri='{}/files/{}'.format(container.uri_as_string(), basename(filepath)), binary_data=f, binary_mimetype=None)
+                new_binary = pcdm.PCDMFile(repo=self.client, uri='{}/files/{}'.format(container.uri_as_string(), basename(filepath)), binary_data=f, binary_mimetype=mimetype)
                 new_binary.create(specify_uri=True, auto_refresh=False)
                 new_binary.add_triple(new_binary.rdf.prefixes.rdfs['label'], basename(filepath))
                 new_binary.add_triple(new_binary.rdf.prefixes.dc['format'], mimetype)

--- a/storer/routines.py
+++ b/storer/routines.py
@@ -144,7 +144,7 @@ class StoreRoutine(Routine):
         except Exception as e:
             raise RoutineError("Error getting data from Archivematica METS file: {}".format(e), self.uuid)
 
-    def get_premis_schemalocation(version):
+    def get_premis_schemalocation(self, version):
         """Returns a PREMIS schema URL based on the version number provided."""
         return 'http://www.loc.gov/premis/v3' if version.startswith("3.") else 'info:lc/xmlns/premis-v2'
 

--- a/storer/routines.py
+++ b/storer/routines.py
@@ -155,7 +155,7 @@ class StoreRoutine(Routine):
         Stores an AIP as a single binary in Fedora and handles the resulting URI.
         Assumes AIPs are stored as a compressed package.
         """
-        self.fedora_client.create_binary(join(self.tmp_dir, "{}{}".format(self.uuid, self.extension)), container, mimetype)
+        self.fedora_client.create_binary(join(self.tmp_dir, "{}{}".format(self.uuid, self.extension)), container, 'application/x-7z-compressed')
 
     def store_dip(self, package, container):
         """

--- a/storer/routines.py
+++ b/storer/routines.py
@@ -131,14 +131,16 @@ class StoreRoutine(Routine):
             mets = helpers.extract_file(join(self.tmp_dir, "{}{}".format(self.uuid, self.extension)), self.mets_path, join(self.tmp_dir, "METS.{}.xml".format(self.uuid)))
             tree = ET.parse(mets)
             root = tree.getroot()
-            ns = {'mets': 'http://www.loc.gov/METS/', 'premis': 'info:lc/xmlns/premis-v2', 'fits': 'http://hul.harvard.edu/ois/xml/ns/fits/fits_output'}
+            ns = {'mets': 'http://www.loc.gov/METS/', 'fits': 'http://hul.harvard.edu/ois/xml/ns/fits/fits_output'}
             internal_sender_identifier = root.find("mets:amdSec/mets:sourceMD/mets:mdWrap[@OTHERMDTYPE='BagIt']/mets:xmlData/transfer_metadata/Internal-Sender-Identifier", ns).text
-            files = root.findall('mets:amdSec/mets:techMD/mets:mdWrap[@MDTYPE="PREMIS:OBJECT"]/mets:xmlData/premis:object', ns)
-            for f in files:
-                uuid = f.find('premis:objectIdentifier/premis:objectIdentifierValue', ns).text
-                identity = f.find('premis:objectCharacteristics/premis:objectCharacteristicsExtension/', ns)
-                mtype = identity.attrib.get('mimetype', 'application/octet-stream') if identity else 'application/octet-stream'
-                mimetypes.update({uuid: mtype})
+            # files = root.findall('mets:amdSec/mets:techMD/mets:mdWrap[@MDTYPE="PREMIS:OBJECT"]/mets:xmlData/', ns)
+            # for f in files:
+            #     version = f.attrib['version']
+            #     ns['premis'] = 'http://www.loc.gov/premis/v3' if version == '3.0' else 'info:lc/xmlns/premis-v2'
+            #     uuid = f.find('premis:objectIdentifier/premis:objectIdentifierValue', ns).text
+            #     identity = f.find('premis:objectCharacteristics/premis:objectCharacteristicsExtension/fits:fits/fits:identification/fits:identity', ns)
+                # mtype = identity.attrib.get('mimetype', 'application/octet-stream') if identity else 'application/octet-stream'
+                # mimetypes.update({uuid: mtype})
             return internal_sender_identifier, mimetypes
         except Exception as e:
             raise RoutineError("Error getting data from Archivematica METS file: {}".format(e), self.uuid)
@@ -153,7 +155,7 @@ class StoreRoutine(Routine):
         Stores an AIP as a single binary in Fedora and handles the resulting URI.
         Assumes AIPs are stored as a compressed package.
         """
-        self.fedora_client.create_binary(join(self.tmp_dir, "{}{}".format(self.uuid, self.extension)), container, 'application/x-7z-compressed')
+        self.fedora_client.create_binary(join(self.tmp_dir, "{}{}".format(self.uuid, self.extension)), container)
 
     def store_dip(self, package, container):
         """
@@ -162,8 +164,8 @@ class StoreRoutine(Routine):
         the mimetypes dictionary to find the relevant mimetype.
         """
         for f in listdir(join(self.extracted, 'objects')):
-            mimetype = self.mimetypes[f[0:36]]
-            self.fedora_client.create_binary(join(self.tmp_dir, self.uuid, 'objects', f), container, mimetype)
+            # mimetype = self.mimetypes[f[0:36]]
+            self.fedora_client.create_binary(join(self.tmp_dir, self.uuid, 'objects', f), container)
 
 
 class CleanupRequester:

--- a/storer/routines.py
+++ b/storer/routines.py
@@ -135,7 +135,7 @@ class StoreRoutine(Routine):
             internal_sender_identifier = root.find("mets:amdSec/mets:sourceMD/mets:mdWrap[@OTHERMDTYPE='BagIt']/mets:xmlData/transfer_metadata/Internal-Sender-Identifier", ns).text
             files = root.findall('mets:amdSec/mets:techMD/mets:mdWrap[@MDTYPE="PREMIS:OBJECT"]/mets:xmlData/', ns)
             for f in files:
-                ns['premis'] = get_premis_schemalocation(f.attrib['version'])
+                ns['premis'] = self.get_premis_schemalocation(f.attrib['version'])
                 uuid = f.find('premis:objectIdentifier/premis:objectIdentifierValue', ns).text
                 identity = f.find('premis:objectCharacteristics/premis:objectCharacteristicsExtension/fits:fits/fits:identification/fits:identity', ns)
                 mtype = identity.attrib.get('mimetype', 'application/octet-stream') if identity else 'application/octet-stream'

--- a/storer/routines.py
+++ b/storer/routines.py
@@ -135,8 +135,7 @@ class StoreRoutine(Routine):
             internal_sender_identifier = root.find("mets:amdSec/mets:sourceMD/mets:mdWrap[@OTHERMDTYPE='BagIt']/mets:xmlData/transfer_metadata/Internal-Sender-Identifier", ns).text
             files = root.findall('mets:amdSec/mets:techMD/mets:mdWrap[@MDTYPE="PREMIS:OBJECT"]/mets:xmlData/', ns)
             for f in files:
-                version = f.attrib['version']
-                ns['premis'] = 'http://www.loc.gov/premis/v3' if version == '3.0' else 'info:lc/xmlns/premis-v2'
+                ns['premis'] = get_premis_schemalocation(f.attrib['version'])
                 uuid = f.find('premis:objectIdentifier/premis:objectIdentifierValue', ns).text
                 identity = f.find('premis:objectCharacteristics/premis:objectCharacteristicsExtension/fits:fits/fits:identification/fits:identity', ns)
                 mtype = identity.attrib.get('mimetype', 'application/octet-stream') if identity else 'application/octet-stream'
@@ -145,7 +144,12 @@ class StoreRoutine(Routine):
         except Exception as e:
             raise RoutineError("Error getting data from Archivematica METS file: {}".format(e), self.uuid)
 
+    def get_premis_schemalocation(version):
+        """Returns a PREMIS schema URL based on the version number provided."""
+        return 'http://www.loc.gov/premis/v3' if version.startswith("3.") else 'info:lc/xmlns/premis-v2'
+
     def clean_up(self, uuid):
+        """Removes files and directories for a given transfer."""
         for d in listdir(self.tmp_dir):
             if uuid in d:
                 helpers.remove_file_or_dir(join(self.tmp_dir, d))

--- a/storer/routines.py
+++ b/storer/routines.py
@@ -155,7 +155,7 @@ class StoreRoutine(Routine):
         Stores an AIP as a single binary in Fedora and handles the resulting URI.
         Assumes AIPs are stored as a compressed package.
         """
-        self.fedora_client.create_binary(join(self.tmp_dir, "{}{}".format(self.uuid, self.extension)), container)
+        self.fedora_client.create_binary(join(self.tmp_dir, "{}{}".format(self.uuid, self.extension)), container, mimetype)
 
     def store_dip(self, package, container):
         """
@@ -165,7 +165,7 @@ class StoreRoutine(Routine):
         """
         for f in listdir(join(self.extracted, 'objects')):
             # mimetype = self.mimetypes[f[0:36]]
-            self.fedora_client.create_binary(join(self.tmp_dir, self.uuid, 'objects', f), container)
+            self.fedora_client.create_binary(join(self.tmp_dir, self.uuid, 'objects', f), container, mimetype)
 
 
 class CleanupRequester:

--- a/storer/routines.py
+++ b/storer/routines.py
@@ -133,14 +133,14 @@ class StoreRoutine(Routine):
             root = tree.getroot()
             ns = {'mets': 'http://www.loc.gov/METS/', 'fits': 'http://hul.harvard.edu/ois/xml/ns/fits/fits_output'}
             internal_sender_identifier = root.find("mets:amdSec/mets:sourceMD/mets:mdWrap[@OTHERMDTYPE='BagIt']/mets:xmlData/transfer_metadata/Internal-Sender-Identifier", ns).text
-            # files = root.findall('mets:amdSec/mets:techMD/mets:mdWrap[@MDTYPE="PREMIS:OBJECT"]/mets:xmlData/', ns)
-            # for f in files:
-            #     version = f.attrib['version']
-            #     ns['premis'] = 'http://www.loc.gov/premis/v3' if version == '3.0' else 'info:lc/xmlns/premis-v2'
-            #     uuid = f.find('premis:objectIdentifier/premis:objectIdentifierValue', ns).text
-            #     identity = f.find('premis:objectCharacteristics/premis:objectCharacteristicsExtension/fits:fits/fits:identification/fits:identity', ns)
-                # mtype = identity.attrib.get('mimetype', 'application/octet-stream') if identity else 'application/octet-stream'
-                # mimetypes.update({uuid: mtype})
+            files = root.findall('mets:amdSec/mets:techMD/mets:mdWrap[@MDTYPE="PREMIS:OBJECT"]/mets:xmlData/', ns)
+            for f in files:
+                version = f.attrib['version']
+                ns['premis'] = 'http://www.loc.gov/premis/v3' if version == '3.0' else 'info:lc/xmlns/premis-v2'
+                uuid = f.find('premis:objectIdentifier/premis:objectIdentifierValue', ns).text
+                identity = f.find('premis:objectCharacteristics/premis:objectCharacteristicsExtension/fits:fits/fits:identification/fits:identity', ns)
+                mtype = identity.attrib.get('mimetype', 'application/octet-stream') if identity else 'application/octet-stream'
+                mimetypes.update({uuid: mtype})
             return internal_sender_identifier, mimetypes
         except Exception as e:
             raise RoutineError("Error getting data from Archivematica METS file: {}".format(e), self.uuid)

--- a/storer/routines.py
+++ b/storer/routines.py
@@ -164,7 +164,7 @@ class StoreRoutine(Routine):
         the mimetypes dictionary to find the relevant mimetype.
         """
         for f in listdir(join(self.extracted, 'objects')):
-            # mimetype = self.mimetypes[f[0:36]]
+            mimetype = self.mimetypes[f[0:36]]
             self.fedora_client.create_binary(join(self.tmp_dir, self.uuid, 'objects', f), container, mimetype)
 
 


### PR DESCRIPTION
Accounts for changes to PREMIS versions in Archivematica METS files by looking for version attribute and setting the schemlocation. 

Takes somewhat of a broad-strokes approach to parsing mimetypes, in that it looks for a mimetype produced by FITS, and if it doesn't find it, uses 'application/octet-stream' which is the most generic mimetype.

Fixes #128 