### PR TITLE
Downgrades rdflib-jsonld, minor code fixes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,4 +17,5 @@ repos:
 - repo: https://github.com/jazzband/pip-tools
   rev: 6.2.0
   hooks:
-    - id: pip-compile
+  - id: pip-compile
+    additional_dependencies: [setuptools]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,4 +18,4 @@ repos:
   rev: 6.2.0
   hooks:
   - id: pip-compile
-    additional_dependencies: [setuptools<58]
+    additional_dependencies: [setuptools<58]  # added to work around use_2to3 error in rdflib-jsonld

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,4 +18,4 @@ repos:
   rev: 6.2.0
   hooks:
   - id: pip-compile
-    additional_dependencies: [setuptools]
+    additional_dependencies: [setuptools<58]

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,9 +16,7 @@ before_install:
   - docker-compose up -d
 install:
   - ./wait-for-it.sh $CONTAINER:$DJANGO_PORT -- docker-compose exec $CONTAINER pip install coverage
-  - pip install "setuptools==40.6.2" && pip freeze && easy_install --version
-  - python -c "import sys; import setuptools; print(setuptools.version.__version__)"
-  - pip install pre-commit && pre-commit install
+  - pip install "pre-commit===2.13.0" && pre-commit install
 script:
   - pre-commit run --all-files --show-diff-on-failure
   - docker-compose exec $CONTAINER coverage run manage.py test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
-cache:
-  directories:
+# cache:
+#   directories:
     - $HOME/.cache/pip
     # - $HOME/.cache/pre-commit
 services:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ before_install:
   - docker-compose up -d
 install:
   - ./wait-for-it.sh $CONTAINER:$DJANGO_PORT -- docker-compose exec $CONTAINER pip install coverage
-  - pip install pre-commit && pre-commit install
+  - pip install setuptools<58 && pip install pre-commit && pre-commit install
 script:
   - pre-commit run --all-files --show-diff-on-failure
   - docker-compose exec $CONTAINER coverage run manage.py test

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ before_install:
   - docker-compose up -d
 install:
   - ./wait-for-it.sh $CONTAINER:$DJANGO_PORT -- docker-compose exec $CONTAINER pip install coverage
-  - pip install "setuptools<58" && pip freeze
+  - pip install "setuptools==40.6.2" && pip freeze
   - pip install pre-commit && pre-commit install
 script:
   - pre-commit run --all-files --show-diff-on-failure

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: python
-# cache:
-#   directories:
-    # - $HOME/.cache/pip
-    # - $HOME/.cache/pre-commit
+cache:
+  directories:
+    - $HOME/.cache/pip
+    - $HOME/.cache/pre-commit
 services:
   - docker
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: python
 cache:
   directories:
     - $HOME/.cache/pip
-    - $HOME/.cache/pre-commit
+    # - $HOME/.cache/pre-commit
 services:
   - docker
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: python
 # cache:
 #   directories:
-    - $HOME/.cache/pip
+    # - $HOME/.cache/pip
     # - $HOME/.cache/pre-commit
 services:
   - docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,8 @@ before_install:
   - docker-compose up -d
 install:
   - ./wait-for-it.sh $CONTAINER:$DJANGO_PORT -- docker-compose exec $CONTAINER pip install coverage
-  - pip install "setuptools<58" && pip install pre-commit && pre-commit install
+  - pip install "setuptools<58" && pip freeze
+  - pip install pre-commit && pre-commit install
 script:
   - pre-commit run --all-files --show-diff-on-failure
   - docker-compose exec $CONTAINER coverage run manage.py test

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,8 @@ before_install:
   - docker-compose up -d
 install:
   - ./wait-for-it.sh $CONTAINER:$DJANGO_PORT -- docker-compose exec $CONTAINER pip install coverage
-  - pip install "setuptools==40.6.2" && pip freeze
+  - pip install "setuptools==40.6.2" && pip freeze && easy_install --version
+  - python -c "import sys; import setuptools; print(setuptools.version.__version__)"
   - pip install pre-commit && pre-commit install
 script:
   - pre-commit run --all-files --show-diff-on-failure

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ before_install:
   - docker-compose up -d
 install:
   - ./wait-for-it.sh $CONTAINER:$DJANGO_PORT -- docker-compose exec $CONTAINER pip install coverage
-  - pip install setuptools<58 && pip install pre-commit && pre-commit install
+  - pip install "setuptools<58" && pip install pre-commit && pre-commit install
 script:
   - pre-commit run --all-files --show-diff-on-failure
   - docker-compose exec $CONTAINER coverage run manage.py test

--- a/requirements.in
+++ b/requirements.in
@@ -7,6 +7,7 @@ jsonschema==3.2.0
 psycopg2-binary==2.9.1
 pyfc4==0.6
 pylzma==0.5.0
+rdflib-jsonld==0.5.0
 requests==2.26.0
 uritemplate==3.0.1
 vcrpy==4.1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -96,8 +96,10 @@ rdflib==5.0.0
     # via
     #   pyfc4
     #   rdflib-jsonld
-rdflib-jsonld==0.6.2
-    # via pyfc4
+rdflib-jsonld==0.5.0
+    # via
+    #   -r requirements.in
+    #   pyfc4
 requests==2.26.0
     # via
     #   -r requirements.in

--- a/storer/routines.py
+++ b/storer/routines.py
@@ -119,7 +119,7 @@ class StoreRoutine(Routine):
             package.process_status = Package.STORED
             package.save()
             stored.append(self.uuid)
-            self.clean_up(self.uuid)
+            self.clean_up(self.uuid, src_file=True)
         msg = "Packages stored." if len(stored) else "No packages to store."
         return (msg, stored)
 
@@ -167,10 +167,11 @@ class StoreRoutine(Routine):
         """Returns a PREMIS schema URL based on the version number provided."""
         return 'http://www.loc.gov/premis/v3' if version.startswith("3.") else 'info:lc/xmlns/premis-v2'
 
-    def clean_up(self, uuid):
-        """Removes files and directories for a given transfer."""
+    def clean_up(self, uuid, src_file=False):
+        """Removes directories for a given transfer. If `src_file` argument is
+        true, removes source file matching the UUID as well."""
         for d in listdir(self.tmp_dir):
-            if uuid in d:
+            if uuid in d and (src_file or isdir(join(self.tmp_dir, d))):
                 remove_file_or_dir(join(self.tmp_dir, d))
 
     def store_aip(self, package, container, mimetypes):
@@ -209,7 +210,8 @@ class PostRoutine:
             package.process_status = self.end_status
             package.save()
             package_ids.append(package.internal_sender_identifier)
-        return (self.success_message, package_ids)
+        msg = self.success_message if len(package_ids) else self.idle_message
+        return (msg, package_ids)
 
 
 class DeliverRoutine(PostRoutine):
@@ -218,6 +220,7 @@ class DeliverRoutine(PostRoutine):
     end_status = Package.DELIVERED
     url = settings.DELIVERY_URL
     success_message = "Package data delivered."
+    idle_message = "No package data waiting to be delivered."
 
     def get_data(self, package):
         return {'identifier': package.internal_sender_identifier,
@@ -233,6 +236,7 @@ class CleanupRequester(PostRoutine):
     end_status = Package.CLEANED_UP
     url = settings.CLEANUP_URL
     success_message = "Requests sent to clean up Packages."
+    idle_message = "No packages waiting for cleanup."
 
     def get_data(self, package):
         return {"identifier": package.internal_sender_identifier}


### PR DESCRIPTION
Downgrades rdflib-jsonld to 0.5.0, since the latest release [is a tombstone without any functionality](https://github.com/RDFLib/rdflib-jsonld). Once we move to Python > 3.6 we'll be able to upgrade. This also required making sure that `pip-tools` is using setuptools<58, since `use_2to3` (which rdflib-jsonld uses) has been deprecated in setuptools as of version 58.

Also makes a few minor adjustments to the cleanup method and idle messages.

Asking for reviews on this so everyone is aware of this dependency issue. A lot going on here.