### PR TITLE
update workflows

### DIFF
--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -24,7 +24,6 @@ jobs:
         with:
           token: ${{ secrets.ACCESS_TOKEN }}
           ref: development
-          persist-credentials: false
 
       - name: Set up Python
         uses: actions/setup-python@v5


### PR DESCRIPTION
removes `persist-credentials` from dependency workflow