### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -14,19 +14,19 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: actions/create-github-app-token@v1
+      - uses: actions/create-github-app-token@v1.11.3
         id: app-token
         with:
           app-id: ${{ vars.APP_ID }}
           private-key: ${{ secrets.PRIVATE_KEY }}
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4.2.2
         with:
           token: ${{ secrets.ACCESS_TOKEN }}
           ref: development
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v5.4.0
         with:
           python-version: '3.10'
           cache: pip

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.2.2
 
       - name: Export secrets to environment variables
         uses: oNaiPs/secrets-to-env-action@v1.5
@@ -65,7 +65,7 @@ jobs:
         run: sudo deploy_scripts/make_zip_django.sh $DEPLOY_ZIP_DIR $DEPLOY_ZIP_NAME
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4.0.3
+        uses: aws-actions/configure-aws-credentials@v4.1.0
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_KEY }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,10 +25,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.2.2
 
       - name: Set up Python and cache pip
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v5.4.0
         with:
           python-version: '3.10'
           cache: 'pip'

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,9 +22,9 @@ certifi==2025.1.31
     # via requests
 charset-normalizer==3.4.1
     # via requests
-coverage[toml]==7.6.10
+coverage[toml]==7.6.11
     # via pytest-cov
-django==4.2.18
+django==4.2.19
     # via
     #   -r requirements.in
     #   asterism


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/create-github-app-token](https://github.com/actions/create-github-app-token)** published a new release **[v1.11.3](https://github.com/actions/create-github-app-token/releases/tag/v1.11.3)** on 2025-02-04T01:08:24Z
* **[actions/setup-python](https://github.com/actions/setup-python)** published a new release **[v5.4.0](https://github.com/actions/setup-python/releases/tag/v5.4.0)** on 2025-01-28T03:28:18Z
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v4.2.2](https://github.com/actions/checkout/releases/tag/v4.2.2)** on 2024-10-23T14:46:00Z
* **[aws-actions/configure-aws-credentials](https://github.com/aws-actions/configure-aws-credentials)** published a new release **[v4.1.0](https://github.com/aws-actions/configure-aws-credentials/releases/tag/v4.1.0)** on 2025-02-10T23:09:32Z
